### PR TITLE
Fix: Make navbar sticky by removing extraneous div

### DIFF
--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -3,9 +3,8 @@ import { Link } from "react-router-dom";
 
 const Navbar = () => {
   return (
-    <div>
-      <nav
-        className="navbar navbar-expand-lg bg-body-tertiary fixed-top"
+    <nav
+      className="navbar navbar-expand-lg bg-body-tertiary fixed-top"
         data-bs-theme="dark"
       >
         <div className="container-fluid">
@@ -69,7 +68,6 @@ const Navbar = () => {
           </div>
         </div>
       </nav>
-    </div>
   );
 };
 


### PR DESCRIPTION
The navbar component was wrapped in an unnecessary div that prevented Bootstrap's `fixed-top` class from working correctly.

This change removes the outer div in `src/Components/Navbar.js`, allowing the navbar to remain fixed at the top of the page during scrolling as intended.